### PR TITLE
Sticky id asserts

### DIFF
--- a/tiled/_tests/test_authentication.py
+++ b/tiled/_tests/test_authentication.py
@@ -426,29 +426,29 @@ def test_session_limit(enter_password, config):
 def test_sticky_identity(enter_password, config):
     # Log in as Alice.
     with Context.from_app(build_app_from_config(config)) as context:
-        get_default_identity(context.api_uri) is None
+        assert get_default_identity(context.api_uri) is None
         with enter_password("secret1"):
             context.authenticate(username="alice")
         assert context.whoami()["identities"][0]["id"] == "alice"
     # The default identity is now set. The log was "sticky".
     with Context.from_app(build_app_from_config(config)) as context:
-        get_default_identity(context.api_uri) is not None
+        assert get_default_identity(context.api_uri) is not None
         context.authenticate()
         assert context.whoami()["identities"][0]["id"] == "alice"
     # Opt out of the stickiness (set_default=False).
     with Context.from_app(build_app_from_config(config)) as context:
-        get_default_identity(context.api_uri) is None
+        assert get_default_identity(context.api_uri) is None
         with enter_password("secret2"):
             context.authenticate(username="bob", set_default=False)
         assert context.whoami()["identities"][0]["id"] == "bob"
     # The default is still Alice.
     with Context.from_app(build_app_from_config(config)) as context:
-        get_default_identity(context.api_uri) is not None
+        assert get_default_identity(context.api_uri) is not None
         context.authenticate()
         assert context.whoami()["identities"][0]["id"] == "alice"
     # Clear the default.
     clear_default_identity(context.api_uri)
-    get_default_identity(context.api_uri) is None
+    assert get_default_identity(context.api_uri) is None
 
 
 def test_api_key_other_principal(enter_password, config):

--- a/tiled/_tests/test_authentication.py
+++ b/tiled/_tests/test_authentication.py
@@ -437,7 +437,9 @@ def test_sticky_identity(enter_password, config):
         assert context.whoami()["identities"][0]["id"] == "alice"
     # Opt out of the stickiness (set_default=False).
     with Context.from_app(build_app_from_config(config)) as context:
-        assert get_default_identity(context.api_uri) is None
+        default = get_default_identity(context.api_uri)
+        assert default is not None
+        assert default.get("username", "bob") != "bob"
         with enter_password("secret2"):
             context.authenticate(username="bob", set_default=False)
         assert context.whoami()["identities"][0]["id"] == "bob"


### PR DESCRIPTION
* test_authentication.py::test_sticky_identity() had some boolean statements that implied an assertion. Those assertions are now explicit
* One of those assertions was failing -- the case labeled "Opt out of the stickiness (set_default=False)".  The logic appeared to be reversed from the intention; that has now been corrected.