### PR TITLE
Export directories (and other container files) by enabling support for `/containers/full` route

### DIFF
--- a/tiled/_tests/test_container_fields.py
+++ b/tiled/_tests/test_container_fields.py
@@ -1,0 +1,57 @@
+import io
+
+import h5py
+import pytest
+
+from ..catalog import in_memory
+from ..catalog.register import register
+from ..client import Context, from_context, record_history
+from ..examples.generate_files import generate_files
+from ..server.app import build_app
+
+
+@pytest.fixture
+def example_data_dir(tmpdir_factory):
+    """
+    Generate a temporary directory with example files.
+
+    The tmpdir_factory fixture ensures that this directory is cleaned up at test exit.
+    """
+    tmpdir = tmpdir_factory.mktemp("example_files")
+    generate_files(tmpdir)
+    return tmpdir
+
+
+@pytest.fixture
+async def awaitable_client_generator(example_data_dir):
+    catalog = in_memory(readable_storage=[example_data_dir])
+    with Context.from_app(build_app(catalog)) as context:
+        client = from_context(context)
+        await register(catalog, example_data_dir)
+        yield client
+
+
+@pytest.fixture
+async def awaitable_client(awaitable_client_generator):
+    return await awaitable_client_generator.__anext__()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fields", (None, (), ("a", "b")))
+async def test_directory_fields(awaitable_client, fields):
+    client = await awaitable_client
+    url_path = client.item["links"]["full"]
+    buffer = io.BytesIO()
+    with record_history() as history:
+        client.export(buffer, fields=fields, format="application/x-hdf5")
+
+    # Directory contents were fetched as a single request using "full" route
+    (request,) = history.requests
+    request_url_path = request.url.copy_with(query=None)
+    assert request_url_path == url_path
+
+    # Only the requested fields were fetched
+    file = h5py.File(buffer, "r")
+    actual_fields = set(file.keys())
+    expected = set(fields or client.keys())  # By default all fields were fetched
+    assert actual_fields == expected

--- a/tiled/_tests/test_container_fields.py
+++ b/tiled/_tests/test_container_fields.py
@@ -3,6 +3,7 @@ import io
 import h5py
 import pandas
 import pytest
+import zarr
 
 from ..catalog import in_memory
 from ..catalog.register import register
@@ -92,6 +93,81 @@ async def test_excel_fields(awaitable_client, fields):
         client.export(buffer, fields=fields, format="application/x-hdf5")
         # TODO: Enable container to export XLSX if all nodes are tables?
         # client.export(buffer, fields=fields, format=XLSX_MIME_TYPE)
+
+    # Spreadsheet contents were fetched as a single request using "full" route
+    for request in history.requests:
+        print(request)
+    (request,) = history.requests
+    request_url_path = request.url.copy_with(query=None)
+    assert request_url_path == url_path
+
+    # Only the requested fields were fetched
+    file = h5py.File(buffer)
+    actual_fields = set(file.keys())
+    expected = set(fields or client.keys())  # By default all fields were fetched
+    assert actual_fields == expected
+
+
+def mark_xfail(value, unsupported="UNSPECIFIED ADAPTER"):
+    "Indicate that this parameterized value is expected to fail"
+    reason = "Tiled does not currently support selecting 'fields' for {unsupported}"
+    return pytest.param(value, marks=pytest.mark.xfail(reason=reason))
+
+
+@pytest.fixture
+def zarr_data_dir(tmpdir):
+    root = zarr.open(str(tmpdir / "zarr_group.zarr"), "w")
+    for i, group in enumerate("abcde"):
+        root.create_dataset(group, data=range(i, i + 3))
+    return tmpdir
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fields", (None, (), mark_xfail(("b", "d"), "Zarr")))
+@awaitable_client_from_data_dir("zarr_data_dir")
+async def test_zarr_group_fields(awaitable_client, fields):
+    client = await awaitable_client
+    client = client["zarr_group"]
+    url_path = client.item["links"]["full"]
+    buffer = io.BytesIO()
+    with record_history() as history:
+        client.export(buffer, fields=fields, format="application/x-hdf5")
+
+    # Spreadsheet contents were fetched as a single request using "full" route
+    for request in history.requests:
+        print(request)
+    (request,) = history.requests
+    request_url_path = request.url.copy_with(query=None)
+    assert request_url_path == url_path
+
+    # Only the requested fields were fetched
+    file = h5py.File(buffer)
+    actual_fields = set(file.keys())
+    expected = set(fields or client.keys())  # By default all fields were fetched
+    assert actual_fields == expected
+
+
+@pytest.fixture
+def hdf5_data_dir(tmpdir):
+    with h5py.File(str(tmpdir / "hdf5_example.h5"), "w") as file:
+        file["x"] = [1, 2, 3]
+        group = file.create_group("g")
+        group["y"] = [4, 5, 6]
+    return tmpdir
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "fields", (None, (), mark_xfail(("x",), "HDF5"), mark_xfail(("g",), "HDF5"))
+)
+@awaitable_client_from_data_dir("hdf5_data_dir")
+async def test_hdf5_fields(awaitable_client, fields):
+    client = await awaitable_client
+    client = client["hdf5_example"]
+    url_path = client.item["links"]["full"]
+    buffer = io.BytesIO()
+    with record_history() as history:
+        client.export(buffer, fields=fields, format="application/x-hdf5")
 
     # Spreadsheet contents were fetched as a single request using "full" route
     for request in history.requests:

--- a/tiled/_tests/test_container_fields.py
+++ b/tiled/_tests/test_container_fields.py
@@ -32,7 +32,6 @@ def example_data_dir(tmpdir_factory):
     return tmpdir
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("fields", (None, (), ("a", "b")))
 @pytest.mark.parametrize("client", ("example_data_dir",), indirect=True)
 def test_directory_fields(client, fields):
@@ -57,7 +56,6 @@ def excel_data_dir(tmpdir_factory):
     return tmpdir
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("fields", (None, (), ("Sheet 1", "Sheet 10")))
 @pytest.mark.parametrize("client", ("excel_data_dir",), indirect=True)
 def test_excel_fields(client, fields):
@@ -90,7 +88,6 @@ def zarr_data_dir(tmpdir_factory):
     return tmpdir
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("fields", (None, (), mark_xfail(("b", "d"), "Zarr")))
 @pytest.mark.parametrize("client", ("zarr_data_dir",), indirect=True)
 def test_zarr_group_fields(client, fields):
@@ -116,7 +113,6 @@ def hdf5_data_dir(tmpdir_factory):
     return tmpdir
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "fields", (None, (), mark_xfail(("x",), "HDF5"), mark_xfail(("g",), "HDF5"))
 )

--- a/tiled/_tests/test_container_fields.py
+++ b/tiled/_tests/test_container_fields.py
@@ -1,6 +1,7 @@
 import io
 
 import h5py
+import pandas
 import pytest
 
 from ..catalog import in_memory
@@ -23,11 +24,12 @@ def example_data_dir(tmpdir_factory):
 
 
 @pytest.fixture
-async def awaitable_client_generator(example_data_dir):
-    catalog = in_memory(readable_storage=[example_data_dir])
+async def awaitable_client_generator(request: pytest.FixtureRequest):
+    data_dir = request.getfixturevalue(request.param)
+    catalog = in_memory(readable_storage=[data_dir])
     with Context.from_app(build_app(catalog)) as context:
         client = from_context(context)
-        await register(catalog, example_data_dir)
+        await register(catalog, data_dir)
         yield client
 
 
@@ -38,6 +40,9 @@ async def awaitable_client(awaitable_client_generator):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("fields", (None, (), ("a", "b")))
+@pytest.mark.parametrize(
+    "awaitable_client_generator", ["example_data_dir"], indirect=True
+)
 async def test_directory_fields(awaitable_client, fields):
     client = await awaitable_client
     url_path = client.item["links"]["full"]
@@ -52,6 +57,44 @@ async def test_directory_fields(awaitable_client, fields):
 
     # Only the requested fields were fetched
     file = h5py.File(buffer, "r")
+    actual_fields = set(file.keys())
+    expected = set(fields or client.keys())  # By default all fields were fetched
+    assert actual_fields == expected
+
+
+@pytest.fixture
+def excel_data_dir(tmpdir):
+    df = pandas.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    with pandas.ExcelWriter(tmpdir / "spreadsheet.xlsx") as writer:
+        for i in range(10):
+            df.to_excel(writer, sheet_name=f"Sheet {i+1}", index=False)
+    return tmpdir
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fields", (None, (), ("Sheet 1", "Sheet 10")))
+@pytest.mark.parametrize(
+    "awaitable_client_generator", ["excel_data_dir"], indirect=True
+)
+async def test_excel_fields(awaitable_client, fields):
+    client = await awaitable_client
+    client = client["spreadsheet"]
+    url_path = client.item["links"]["full"]
+    buffer = io.BytesIO()
+    with record_history() as history:
+        client.export(buffer, fields=fields, format="application/x-hdf5")
+        # TODO: Enable container to export XLSX if all nodes are tables?
+        # client.export(buffer, fields=fields, format=XLSX_MIME_TYPE)
+
+    # Spreadsheet contents were fetched as a single request using "full" route
+    for request in history.requests:
+        print(request)
+    (request,) = history.requests
+    request_url_path = request.url.copy_with(query=None)
+    assert request_url_path == url_path
+
+    # Only the requested fields were fetched
+    file = h5py.File(buffer)
     actual_fields = set(file.keys())
     expected = set(fields or client.keys())  # By default all fields were fetched
     assert actual_fields == expected

--- a/tiled/_tests/test_container_fields.py
+++ b/tiled/_tests/test_container_fields.py
@@ -15,6 +15,7 @@ from ..server.app import build_app
 
 @pytest.fixture(scope="module")
 def client(request: pytest.FixtureRequest):
+    "A tiled client that serves from parametrized data_dir (Path or str)"
     data_dir = request.getfixturevalue(request.param)
     catalog = in_memory(readable_storage=[data_dir])
     with Context.from_app(build_app(catalog)) as context:
@@ -35,6 +36,7 @@ def example_data_dir(tmpdir_factory):
 @pytest.mark.parametrize("fields", (None, (), ("a", "b")))
 @pytest.mark.parametrize("client", ("example_data_dir",), indirect=True)
 def test_directory_fields(client, fields):
+    "Export selected fields (files) from a directory via /container/full."
     url_path = client.item["links"]["full"]
     buffer = io.BytesIO()
     with record_history() as history:
@@ -46,6 +48,7 @@ def test_directory_fields(client, fields):
 
 @pytest.fixture(scope="module")
 def excel_data_dir(tmpdir_factory):
+    "Generate a temporary Excel file with multiple Sheets of tabular data."
     tmpdir = tmpdir_factory.mktemp("excel_files")
     df = pandas.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     with pandas.ExcelWriter(tmpdir / "spreadsheet.xlsx") as writer:
@@ -58,6 +61,7 @@ def excel_data_dir(tmpdir_factory):
 @pytest.mark.parametrize("fields", (None, (), ("Sheet 1", "Sheet 10")))
 @pytest.mark.parametrize("client", ("excel_data_dir",), indirect=True)
 def test_excel_fields(client, fields):
+    "Export selected fields (sheets) from an Excel file via /container/full."
     client = client["spreadsheet"]
     url_path = client.item["links"]["full"]
     buffer = io.BytesIO()
@@ -78,10 +82,11 @@ def mark_xfail(value, unsupported="UNSPECIFIED ADAPTER"):
 
 @pytest.fixture(scope="module")
 def zarr_data_dir(tmpdir_factory):
+    "Generate a temporary Zarr group file with multiple datasets."
     tmpdir = tmpdir_factory.mktemp("zarr_files")
     root = zarr.open(str(tmpdir / "zarr_group.zarr"), "w")
-    for i, group in enumerate("abcde"):
-        root.create_dataset(group, data=range(i, i + 3))
+    for i, name in enumerate("abcde"):
+        root.create_dataset(name, data=range(i, i + 3))
     return tmpdir
 
 
@@ -89,6 +94,7 @@ def zarr_data_dir(tmpdir_factory):
 @pytest.mark.parametrize("fields", (None, (), mark_xfail(("b", "d"), "Zarr")))
 @pytest.mark.parametrize("client", ("zarr_data_dir",), indirect=True)
 def test_zarr_group_fields(client, fields):
+    "Export selected fields (Datasets) from a Zarr group via /container/full."
     client = client["zarr_group"]
     url_path = client.item["links"]["full"]
     buffer = io.BytesIO()
@@ -101,6 +107,7 @@ def test_zarr_group_fields(client, fields):
 
 @pytest.fixture(scope="module")
 def hdf5_data_dir(tmpdir_factory):
+    "Generate a temporary HDF5 file with multiple entries."
     tmpdir = tmpdir_factory.mktemp("hdf5_files")
     with h5py.File(str(tmpdir / "hdf5_example.h5"), "w") as file:
         file["x"] = [1, 2, 3]
@@ -115,6 +122,7 @@ def hdf5_data_dir(tmpdir_factory):
 )
 @pytest.mark.parametrize("client", ("hdf5_data_dir",), indirect=True)
 def test_hdf5_fields(client, fields):
+    "Export selected fields (array/group) from a HDF5 file via /container/full."
     client = client["hdf5_example"]
     url_path = client.item["links"]["full"]
     buffer = io.BytesIO()
@@ -126,14 +134,14 @@ def test_hdf5_fields(client, fields):
 
 
 def assert_single_request_to_url(history, url_path):
-    "Container contents were fetched as a single request using 'full' route"
+    "Container contents were fetched as a single request using 'full' route."
     (request,) = history.requests
     request_url_path = request.url.copy_with(query=None)
     assert request_url_path == url_path
 
 
 def assert_requested_fields_fetched(buffer, fields, client):
-    "Only the requested fields were fetched"
+    "Only the requested fields were fetched."
     file = h5py.File(buffer)
     actual_fields = set(file.keys())
     expected = set(fields or client.keys())  # By default all fields were fetched

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -1,5 +1,6 @@
 import collections
 import importlib
+import itertools as it
 import operator
 import os
 import re
@@ -859,9 +860,11 @@ class CatalogContainerAdapter(CatalogNodeAdapter):
 
     async def items_range(self, offset, limit):
         if self.data_sources:
-            return (await self.get_adapter()).items()[
-                offset : (offset + limit) if limit is not None else None  # noqa: E203
-            ]
+            return it.islice(
+                (await self.get_adapter()).items(),
+                offset,
+                (offset + limit) if limit is not None else None  # noqa: E203
+            )
         statement = select(orm.Node).filter(orm.Node.ancestors == self.segments)
         for condition in self.conditions:
             statement = statement.filter(condition)

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -863,7 +863,7 @@ class CatalogContainerAdapter(CatalogNodeAdapter):
             return it.islice(
                 (await self.get_adapter()).items(),
                 offset,
-                (offset + limit) if limit is not None else None  # noqa: E203
+                (offset + limit) if limit is not None else None,  # noqa: E203
             )
         statement = select(orm.Node).filter(orm.Node.ancestors == self.segments)
         for condition in self.conditions:

--- a/tiled/catalog/adapter.py
+++ b/tiled/catalog/adapter.py
@@ -839,9 +839,11 @@ class CatalogNodeAdapter:
 class CatalogContainerAdapter(CatalogNodeAdapter):
     async def keys_range(self, offset, limit):
         if self.data_sources:
-            return (await self.get_adapter()).keys()[
-                offset : (offset + limit) if limit is not None else None  # noqa: E203
-            ]
+            return it.islice(
+                (await self.get_adapter()).keys(),
+                offset,
+                (offset + limit) if limit is not None else None,  # noqa: E203
+            )
         statement = select(orm.Node.key).filter(orm.Node.ancestors == self.segments)
         for condition in self.conditions:
             statement = statement.filter(condition)

--- a/tiled/serialization/container.py
+++ b/tiled/serialization/container.py
@@ -2,7 +2,12 @@ import io
 
 from ..media_type_registration import serialization_registry
 from ..structures.core import StructureFamily
-from ..utils import SerializationError, ensure_awaitable, modules_available, safe_json_dump
+from ..utils import (
+    SerializationError,
+    ensure_awaitable,
+    modules_available,
+    safe_json_dump,
+)
 
 
 async def walk(node, filter_for_access, pre=None):

--- a/tiled/serialization/container.py
+++ b/tiled/serialization/container.py
@@ -2,7 +2,7 @@ import io
 
 from ..media_type_registration import serialization_registry
 from ..structures.core import StructureFamily
-from ..utils import SerializationError, modules_available, safe_json_dump
+from ..utils import SerializationError, ensure_awaitable, modules_available, safe_json_dump
 
 
 async def walk(node, filter_for_access, pre=None):
@@ -65,7 +65,7 @@ if modules_available("h5py"):
                             group.attrs.update(node.metadata())
                         except TypeError:
                             raise SerializationError(MSG)
-                data = array_adapter.read()
+                data = await ensure_awaitable(array_adapter.read)
                 dataset = group.create_dataset(key_path[-1], data=data)
                 for k, v in array_adapter.metadata().items():
                     dataset.attrs.create(k, v)

--- a/tiled/server/router.py
+++ b/tiled/server/router.py
@@ -799,7 +799,7 @@ async def container_full(
         )
     try:
         with record_timing(request.state.metrics, "read"):
-            data = await ensure_awaitable(entry.read, field)
+            data = await ensure_awaitable(entry.read, fields=field)
     except KeyError as err:
         (key,) = err.args
         raise HTTPException(status_code=400, detail=f"No such field {key}.")

--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -660,7 +660,9 @@ async def ensure_awaitable(func, *args, **kwargs):
     else:
         # run_sync() does not apply **kwargs to func
         # https://github.com/agronholm/anyio/issues/414
-        func_with_kwargs = lambda *args: func(*args, **kwargs)
+        def func_with_kwargs(*args):
+            return func(*args, **kwargs)
+
         return await anyio.to_thread.run_sync(func_with_kwargs, *args)
 
 

--- a/tiled/utils.py
+++ b/tiled/utils.py
@@ -658,7 +658,10 @@ async def ensure_awaitable(func, *args, **kwargs):
     if is_coroutine_callable(func):
         return await func(*args, **kwargs)
     else:
-        return await anyio.to_thread.run_sync(func, *args, **kwargs)
+        # run_sync() does not apply **kwargs to func
+        # https://github.com/agronholm/anyio/issues/414
+        func_with_kwargs = lambda *args: func(*args, **kwargs)
+        return await anyio.to_thread.run_sync(func_with_kwargs, *args)
 
 
 def path_from_uri(uri):


### PR DESCRIPTION
Calling `client.Container.export()` fails when exporting to the default serialization format, "application/x-hdf5".

This PR fixes that functionality with the following updates: 
* `CatalogContainerAdapter.items_range()` now supports slicing for item generators (in addition to previously supported subscriptable items).
* `serialize_hdf5()` now support both async and sync reads, including `CatalogArrayAdapter.read()`.

Additionally exporting selected "fields" now works correctly, using `client.Container.export(..., fields=...)` or `GET /container/full?field=...`:
* `/container/full` routes now pass requested fields to `CatalogArrayAdapter.read()` as originally intended.
* `ensure_awaitable()` now correctly handles `**kwargs` for synchronous callables.